### PR TITLE
Support setting statsd metric aggregation interval

### DIFF
--- a/agent.yaml.template
+++ b/agent.yaml.template
@@ -125,7 +125,7 @@ Statsd:
   monasca_statsd_port : {args.monasca_statsd_port}
 
   ## The monasca_statsd flush period.
-  # monasca_statsd_interval : 20
+  monasca_statsd_interval : {args.monasca_statsd_interval}
 
   # If you want to forward every packet received by the monasca_statsd server
   # to another statsd server, uncomment these lines.

--- a/docs/Agent.md
+++ b/docs/Agent.md
@@ -112,6 +112,7 @@ All parameters require a '--' before the parameter such as '--verbose'. Run `mon
 | backlog_send_rate | Integer value of how many batches of buffered measurements to send each time the forwarder flushes data | 1000 |
 | max_batch_size | Maximum batch size of measurements to write to monasca-api, 0 is no limit | 0 |
 | monasca_statsd_port | Integer value for statsd daemon port number | 8125 |
+| monasca_statsd_interval | Integer value for the statsd metric aggregation interval (seconds) | 20 |
 
 #### A note around using monasca-agent with different versions of Keystone
 

--- a/monasca_setup/main.py
+++ b/monasca_setup/main.py
@@ -304,6 +304,9 @@ def parse_arguments(parser):
     parser.add_argument('--monasca_statsd_port',
                         help="Statsd daemon port number",
                         default=8125)
+    parser.add_argument('--monasca_statsd_interval',
+                        help="Statsd metric aggregation interval (seconds)",
+                        default=20)
     parser.add_argument('--agent_service_name',
                         help="agent's systemd/sysv service name",
                         required=False,


### PR DESCRIPTION
This adds support for setting the statsd metrics aggregation interval
as part of Monasca setup. Setting this interval is useful for users
calculating rates from statsd metrics.

Story: 2005063
Task: 29607
Change-Id: I22f5f1700c438245fd7e98deb40d706358349b6c